### PR TITLE
Fix rate limiting on scan

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,11 @@
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Metrics/MethodLength:
+  Max: 50
+
+Metrics/BlockLength:
+  Max: 200

--- a/bin/check-container-vulnerabilities.rb
+++ b/bin/check-container-vulnerabilities.rb
@@ -44,8 +44,9 @@ class CheckContainerVulnerabilities < Sensu::Plugin::Check::CLI
          proc: proc { |w| w.split(',') }
 
   def run
-    status, message = Quayio::Scanner::Check.new(
-        config[:docker_url], config[:quayio_token], config[:whitelist]).run
+    status, message = Quayio::Scanner::Check.new(config[:docker_url],
+                                                 config[:quayio_token],
+                                                 config[:whitelist]).run
 
     if status == :ok
       ok message

--- a/lib/quayio/scanner.rb
+++ b/lib/quayio/scanner.rb
@@ -1,5 +1,8 @@
-require 'quayio/scanner/version'
 require 'quayio/scanner/check'
+require 'quayio/scanner/image'
+require 'quayio/scanner/repository'
+require 'quayio/scanner/version'
+
 
 module Quayio
   module Scanner

--- a/lib/quayio/scanner.rb
+++ b/lib/quayio/scanner.rb
@@ -3,7 +3,6 @@ require 'quayio/scanner/image'
 require 'quayio/scanner/repository'
 require 'quayio/scanner/version'
 
-
 module Quayio
   module Scanner
   end

--- a/lib/quayio/scanner/check.rb
+++ b/lib/quayio/scanner/check.rb
@@ -1,4 +1,3 @@
-require 'quayio/scanner/image'
 require 'docker'
 
 module Quayio

--- a/lib/quayio/scanner/check.rb
+++ b/lib/quayio/scanner/check.rb
@@ -2,23 +2,31 @@ require 'docker'
 
 module Quayio
   module Scanner
-    class Check < Struct.new(:docker_url, :quayio_token, :whitelist)
+    Check = Struct.new(:docker_url, :quayio_token, :whitelist) do
       def run
         Docker.url = docker_url
-        containers = Docker::Container.all
-                                      .map { |dc| dc.json['Config']['Image'] }
-                                      .uniq
-
-        vulnerable_images = containers
-                            .map { |container| Image.new(container, quayio_token, whitelist) }
-                            .select(&:vulnerable?)
-                            .map(&:name)
 
         if vulnerable_images.empty?
           [:ok, "#{containers.size} Containers are ok"]
         else
           [:critical, "The images are insecure: #{vulnerable_images.join(', ')}"]
         end
+      end
+
+      private
+
+      def containers
+        Docker::Container
+          .all
+          .map { |dc| dc.json['Config']['Image'] }
+          .uniq
+      end
+
+      def vulnerable_images
+        containers
+          .map { |container| Image.new(container, quayio_token, whitelist) }
+          .select(&:vulnerable?)
+          .map(&:name)
       end
     end
   end

--- a/lib/quayio/scanner/image.rb
+++ b/lib/quayio/scanner/image.rb
@@ -4,7 +4,7 @@ module Quayio
       RELEVANT_SEVERITIES = %w[High Critical].freeze
       QUAY_IO_REPO_NAME = %r{quay.io\/(?<org>[\w-]+)\/(?<repo>[\w-]+):(?<tag>[\w\.-]+)}.freeze
 
-      attr_reader :name
+      attr_reader :name, :whitelist, :repository
 
       def initialize(name, quayio_token, whitelist)
         @name = name
@@ -22,10 +22,9 @@ module Quayio
 
       private
 
-      attr_reader :whitelist, :repository
-
       def quayio?
-        !!repository
+        # safe guard, do not trust QUAY_IO_REPO_NAME regex match
+        name.match(%r{^quay.io\/})
       end
 
       def scanned?

--- a/lib/quayio/scanner/image.rb
+++ b/lib/quayio/scanner/image.rb
@@ -1,8 +1,8 @@
 module Quayio
   module Scanner
     class Image
-      RELEVANT_SEVERITIES = %w(High Critical)
-      QUAY_IO_REPO_NAME = /quay.io\/(?<org>[\w-]+)\/(?<repo>[\w-]+):(?<tag>[\w\.-]+)/
+      RELEVANT_SEVERITIES = %w[High Critical].freeze
+      QUAY_IO_REPO_NAME = %r{quay.io\/(?<org>[\w-]+)\/(?<repo>[\w-]+):(?<tag>[\w\.-]+)}.freeze
 
       attr_reader :name
 
@@ -34,7 +34,7 @@ module Quayio
 
       def vulnerabilities_present?
         raw_scan['data']['Layer']['Features'].detect do |f|
-          f['Vulnerabilities'] && f['Vulnerabilities'].detect do |v|
+          f['Vulnerabilities']&.detect do |v|
             RELEVANT_SEVERITIES.include?(v['Severity']) && !whitelist.include?(v['Name'])
           end
         end

--- a/lib/quayio/scanner/image.rb
+++ b/lib/quayio/scanner/image.rb
@@ -1,78 +1,61 @@
-require 'json'
-require 'rest-client'
+require 'quayio/scanner/repository'
 
 module Quayio
   module Scanner
-    class Image < Struct.new(:name, :quayio_token, :whitelist)
+    class Image
       RELEVANT_SEVERITIES = %w(High Critical)
-      MAX_ATTEMPTS = 5
+
+      def initialize(name, quayio_token, whitelist)
+        @name = name
+        @whitelist = whitelist
+
+        repo = name.split(':').first.gsub(%r{quay.io\/}, '')
+        @repository = Repository.new(quayio_token, repo)
+      end
 
       def vulnerable?
-        quayio? && image_exists? && scanned? && high_vulnerabilities_present?
+        quayio? && image_exists? && scanned? && vulnerabilities_present?
       end
 
       private
 
       def quayio?
-        name.match(%r{^quay.io\/})
+        @name.match(%r{^quay.io\/})
       end
 
       def image_exists?
-        raw_image
+        raw_id
       end
 
       def scanned?
         raw_scan['status'] == 'scanned'
       end
 
-      def high_vulnerabilities_present?
+      def vulnerabilities_present?
         raw_scan['data']['Layer']['Features'].detect do |f|
           f['Vulnerabilities'] && f['Vulnerabilities'].detect do |v|
             RELEVANT_SEVERITIES.include?(v['Severity']) &&
-              !whitelist.include?(v['Name'])
+              !@whitelist.include?(v['Name'])
           end
         end
-      end
-
-      def repo
-        name.split(':').first.gsub(%r{quay.io\/}, '')
       end
 
       def tag
-        name.split(':').last
+        @name.split(':').last
       end
 
-      def raw_image
-        return @raw_image if defined? @raw_image
+      def raw_id
+        return @raw_id if defined? @raw_id
 
-        (1..MAX_ATTEMPTS).each do |attempt|
-          begin
-            response = RestClient.get(
-              "https://quay.io/api/v1/repository/#{repo}/tag/#{tag}/images",
-              authorization: "Bearer #{quayio_token}",
-              accept: :json)
-          rescue RestClient::ExceptionWithResponse => err
-            return nil if err.http_code == 404 # ignore unknown repos
-            if err.http_code == 520 and attempt < MAX_ATTEMPTS
-              sleep(rand(10))
-              next
-            end
-            raise err
-          end
-          @raw_image = JSON.parse(response)['images'].first
-          return @raw_image
-        end
+        @raw_id = @repository.id(tag)
+        return @raw_id
       end
 
       def raw_scan
         return @raw_scan if defined? @raw_scan
 
-        @raw_scan = begin
-          JSON.parse(
-            RestClient.get("https://quay.io/api/v1/repository/#{repo}/image/#{raw_image['id']}/security?vulnerabilities=true",
-                           authorization: "Bearer #{quayio_token}", accept: :json)
-          )
-        end
+        @raw_scan = @repository.scan(raw_id)
+        return @raw_scan
       end
     end
   end

--- a/lib/quayio/scanner/image.rb
+++ b/lib/quayio/scanner/image.rb
@@ -24,7 +24,7 @@ module Quayio
 
       def quayio?
         # safe guard, do not trust QUAY_IO_REPO_NAME regex match
-        name.match(%r{^quay.io\/})
+        !!name.match(%r{^quay.io\/})
       end
 
       def scanned?
@@ -32,7 +32,7 @@ module Quayio
       end
 
       def vulnerabilities_present?
-        raw_scan['data']['Layer']['Features'].detect do |f|
+        !!raw_scan['data']['Layer']['Features'].detect do |f|
           f['Vulnerabilities']&.detect do |v|
             RELEVANT_SEVERITIES.include?(v['Severity']) && !whitelist.include?(v['Name'])
           end

--- a/lib/quayio/scanner/image.rb
+++ b/lib/quayio/scanner/image.rb
@@ -1,30 +1,31 @@
-require 'quayio/scanner/repository'
-
 module Quayio
   module Scanner
     class Image
       RELEVANT_SEVERITIES = %w(High Critical)
+      QUAY_IO_REPO_NAME = /quay.io\/(?<org>[\w-]+)\/(?<repo>[\w-]+):(?<tag>[\w\.-]+)/
+
+      attr_reader :name
 
       def initialize(name, quayio_token, whitelist)
         @name = name
         @whitelist = whitelist
 
-        repo = name.split(':').first.gsub(%r{quay.io\/}, '')
-        @repository = Repository.new(quayio_token, repo)
+        @name.match(QUAY_IO_REPO_NAME) do |r|
+          org, repo, tag = r.captures
+          @repository = Repository.new(quayio_token, org, repo, tag)
+        end
       end
 
       def vulnerable?
-        quayio? && image_exists? && scanned? && vulnerabilities_present?
+        quayio? && scanned? && vulnerabilities_present?
       end
 
       private
 
-      def quayio?
-        @name.match(%r{^quay.io\/})
-      end
+      attr_reader :whitelist, :repository
 
-      def image_exists?
-        raw_id
+      def quayio?
+        !!repository
       end
 
       def scanned?
@@ -34,28 +35,13 @@ module Quayio
       def vulnerabilities_present?
         raw_scan['data']['Layer']['Features'].detect do |f|
           f['Vulnerabilities'] && f['Vulnerabilities'].detect do |v|
-            RELEVANT_SEVERITIES.include?(v['Severity']) &&
-              !@whitelist.include?(v['Name'])
+            RELEVANT_SEVERITIES.include?(v['Severity']) && !whitelist.include?(v['Name'])
           end
         end
       end
 
-      def tag
-        @name.split(':').last
-      end
-
-      def raw_id
-        return @raw_id if defined? @raw_id
-
-        @raw_id = @repository.id(tag)
-        return @raw_id
-      end
-
       def raw_scan
-        return @raw_scan if defined? @raw_scan
-
-        @raw_scan = @repository.scan(raw_id)
-        return @raw_scan
+        @raw_scan ||= repository.scan
       end
     end
   end

--- a/lib/quayio/scanner/repository.rb
+++ b/lib/quayio/scanner/repository.rb
@@ -1,0 +1,44 @@
+require 'rest-client'
+require 'json'
+
+module Quayio
+  module Scanner
+    class Repository < Struct.new(:quayio_token, :repo)
+      MAX_ATTEMPTS = 5
+
+      def id(tag)
+        begin
+          images = api_call("/tag/#{tag}/images")
+        rescue RestClient::ExceptionWithResponse => err
+          return nil if err.http_code == 404 # ingnore unknown repos
+          raise err
+        end
+        return (images['images'].first)['id']
+      end
+
+      def scan(id)
+        return api_call("/image/#{id}/security?vulnerabilities=true")
+      end
+
+      private
+
+      def api_call(uri)
+        (1..Float::INFINITY).each do |attempt|
+          begin
+            response = RestClient.get(
+              "https://quay.io/api/v1/repository/#{repo}#{uri}",
+              authorization: "Bearer #{quayio_token}",
+              accept: :json)
+            return JSON.parse(response)
+          rescue RestClient::ExceptionWithResponse => err
+            if err.http_code == 520 and attempt < MAX_ATTEMPTS
+              sleep(rand(10))
+              next
+            end
+            raise err
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/quayio/scanner/repository.rb
+++ b/lib/quayio/scanner/repository.rb
@@ -7,13 +7,8 @@ module Quayio
       MAX_ATTEMPTS = 5
 
       def id(tag)
-        begin
-          images = api_call("/tag/#{tag}/images")
-          return (images['images'].first)['id']
-        rescue RestClient::ExceptionWithResponse => err
-          return nil if err.http_code == 404 # ingnore unknown repos
-          raise err
-        end
+        result = api_call("/tag/#{tag}/images")
+        return (result['images'].first)['id']
       end
 
       def scan(id)

--- a/lib/quayio/scanner/repository.rb
+++ b/lib/quayio/scanner/repository.rb
@@ -9,11 +9,11 @@ module Quayio
       def id(tag)
         begin
           images = api_call("/tag/#{tag}/images")
+          return (images['images'].first)['id']
         rescue RestClient::ExceptionWithResponse => err
           return nil if err.http_code == 404 # ingnore unknown repos
           raise err
         end
-        return (images['images'].first)['id']
       end
 
       def scan(id)
@@ -31,11 +31,8 @@ module Quayio
               accept: :json)
             return JSON.parse(response)
           rescue RestClient::ExceptionWithResponse => err
-            if err.http_code == 520 and attempt < MAX_ATTEMPTS
-              sleep(rand(10))
-              next
-            end
-            raise err
+            raise err if err.http_code != 520 or attempt >= MAX_ATTEMPTS
+            sleep(rand(10))
           end
         end
       end

--- a/quayio-scanner.gemspec
+++ b/quayio-scanner.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/aboutsource/quayio-scanner'
   spec.license       = 'MIT'
 
+  spec.required_ruby_version = '>= 2.4.0'
+
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end

--- a/quayio-scanner.gemspec
+++ b/quayio-scanner.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'docker-api', '~> 1.33'
   spec.add_dependency 'rest-client', '~> 2.0'
   spec.add_dependency 'sensu-plugin', '~> 2.1'
-  spec.add_development_dependency 'bundler', '~> 1.14'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.7'
   spec.add_development_dependency 'rubocop', '~> 0.49'


### PR DESCRIPTION
Der Check ruft zweimal die QuayIO-API auf. Der Schutz gegen Rate-Limiting war aber nur an einem Aufruf implementiert. Ich habe den Moment genutzt, um die API-Calls zu generalisieren und in eine eigene Klasse zu kapseln.