### PR TITLE
add cli flag to ignore quay.io namespace names

### DIFF
--- a/bin/check-container-vulnerabilities.rb
+++ b/bin/check-container-vulnerabilities.rb
@@ -44,10 +44,18 @@ class CheckContainerVulnerabilities < Sensu::Plugin::Check::CLI
          default: '',
          proc: proc { |w| w.split(',') }
 
+  option :ignore_namespace_names,
+         description: 'Namespace names to ignore',
+         short: '-n NAMESPACE_NAME[,NAMESPACE_NAME]',
+         long: '--ignore-namespace-names NAMESPACE_NAME[,NAMESPACE_NAME]',
+         default: '',
+         proc: proc { |w| w.split(',') }
+
   def run
     status, message = Quayio::Scanner::Check.new(config[:docker_url],
                                                  config[:quayio_token],
-                                                 config[:whitelist]).run
+                                                 config[:whitelist],
+                                                 config[:ignore_namespace_names]).run
 
     if status == :ok
       ok message

--- a/lib/quayio/scanner/check.rb
+++ b/lib/quayio/scanner/check.rb
@@ -2,7 +2,7 @@ require 'docker'
 
 module Quayio
   module Scanner
-    Check = Struct.new(:docker_url, :quayio_token, :whitelist) do
+    Check = Struct.new(:docker_url, :quayio_token, :whitelist, :ignore_namespace_names) do
       def run
         Docker.url = docker_url
 
@@ -27,7 +27,7 @@ module Quayio
 
       def vulnerable_images
         containers
-          .map { |container| Image.new(container, quayio_token, whitelist) }
+          .map { |container| Image.new(container, quayio_token, whitelist, ignore_namespace_names) }
           .select(&:vulnerable?)
           .map(&:name)
       end

--- a/lib/quayio/scanner/image.rb
+++ b/lib/quayio/scanner/image.rb
@@ -5,11 +5,12 @@ module Quayio
       QUAY_IO_REPO_NAME =
         %r{quay.io\/(?<org>[\w-]+)\/(?<repo>[\w-]+):(?<tag>[\w.-]+)}.freeze
 
-      attr_reader :name, :whitelist, :repository
+      attr_reader :name, :whitelist, :repository, :ignore_namespace_names
 
-      def initialize(name, quayio_token, whitelist)
+      def initialize(name, quayio_token, whitelist, ignore_namespace_names)
         @name = name
         @whitelist = whitelist
+        @ignore_namespace_names = ignore_namespace_names
 
         @name.match(QUAY_IO_REPO_NAME) do |r|
           org, repo, tag = r.captures
@@ -36,7 +37,8 @@ module Quayio
         !raw_scan['data']['Layer']['Features'].detect do |f|
           f['Vulnerabilities']&.detect do |v|
             RELEVANT_SEVERITIES.include?(v['Severity']) && \
-              !whitelist.include?(v['Name'])
+              !whitelist.include?(v['Name']) && \
+              !ignore_namespace_names.include?(v['NamespaceName'])
           end
         end.nil?
       end


### PR DESCRIPTION
Der Parameter heißt leider total bekloppt. Das Naming kommt von quay.io. Das relevante Datenfeld heißt tatsächlich `NamespaceNames`.  Die Doku und das UI von quay.io gibt auch keinen besseren Namen her, daher habe ich das einfach stumpf übernommen.